### PR TITLE
Feature - Release Cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,28 @@ This command generates static content into the `build` directory and can be serv
 2. update your changes in a feature branch
 3. Push to your fork's origin
 4. Create a Pull Request from your Fork to the Upstream master.
+
+```bash
+# fork the repository on Github.
+# https://github.com/codeontap/hamlet-docs.git
+
+# add your upstream repo
+git remote add upstream https://github.com/codeontap/hamlet-docs.git
+
+# create your working branch
+git checkout -b feature-my-feature-branch
+
+# make your changes / updates / fixes in as many commits as necessary.
+
+# rebase your work into only relevant commit messages
+# example: I've made 3 commits, but two of them are fixups.
+# git rebase -i HEAD~3
+# mark the fixups and save the commits
+git rebase -i HEAD~<number of commits since HEAD>
+
+# push your feature branch to your origin (the fork)
+git push --set-upstream origin feature-my-feature-branch
+
+# on Github, create a PR from your fork/feature-branch to upstream/master.
+# make sure you complete any Issue/PR templates provided.
+```

--- a/docs/developer-guides/release-schedule.md
+++ b/docs/developer-guides/release-schedule.md
@@ -1,6 +1,6 @@
 ---
-sidebar_label: release process
-title: Release Process
+sidebar_label: release schedule
+title: Release Schedule
 ---
 
 `hamlet` releases follow the release train model [Spotify Example](https://labs.spotify.com/2014/03/27/spotify-engineering-culture-part-1/) [Agile Description](https://www.scaledagileframework.com/agile-release-train/) where releases are made at scheduled intervals. With this model all commits to the master branch should be considered release candidates.
@@ -11,7 +11,7 @@ Our release cycle is structured into three stages. The releases are structured t
 
 ### Train
 
-The train release is the stable product release which is the recommended release of `hamlet`. The train is scheduled quarterly and the timetable is available here: https://github.com/`hamlet`/`hamlet`/milestones
+The train release is the stable product release which is the recommended release of `hamlet`. The train is scheduled quarterly and the timetable is available here: https://github.com/hamlet/hamlet/milestones
 
 ### Tram
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
         {to: 'blog', label: 'releases', position: 'left'},
         {to: 'https://github.com/orgs/codeontap/projects', label: 'roadmap', position: 'right'},
         {to: "contribute", label: 'contribute', position: 'right'},
-        {to: "https://gitter.im/hamlet-devops/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link", label: 'community', position: 'right'},
+        {to: "https://gitter.im/hamlet-io/community", label: 'community', position: 'right'},
       ],
     },
     algolia: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,6 +17,7 @@ module.exports = {
       links: [
         {to: 'docs/index', label: 'docs', position: 'left'},
         {to: 'blog', label: 'releases', position: 'left'},
+        {to: 'docs/developer-guides/release-schedule', label: 'schedule', position: 'left'},
         {to: 'https://github.com/orgs/codeontap/projects', label: 'roadmap', position: 'right'},
         {to: "contribute", label: 'contribute', position: 'right'},
         {to: "https://gitter.im/hamlet-io/community", label: 'community', position: 'right'},

--- a/sidebars.js
+++ b/sidebars.js
@@ -99,6 +99,7 @@ module.exports = {
       label: 'Contributor Guides',
       items: [
         'developer-guides/index',
+        'developer-guides/release-schedule',
         'developer-guides/aws-data-pipeline',
       ]
     },


### PR DESCRIPTION
Contributes to #8 

This PR re-introduces the release cycle documentation from the original readthedocs site.
The file is a mardown file so its listed in the docs, however due to its importance its also been added to navigation bar. When navbar drop-down menus are available for use in docusaurus, the navbar link "releases" will become a heading and we'll put "latest releases" and "schedule" underneath.