### PR TITLE
Adds basic schema documents

### DIFF
--- a/static/schema/latest/blueprint.json
+++ b/static/schema/latest/blueprint.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://hamlet.io/static/schema/latest/blueprint.json",
+    "$id": "http://hamlet.io/schema/latest/blueprint.json",
 
     "type": "object",
 
@@ -23,7 +23,7 @@
         "patternProperties": {
             "^[A-Za-z0-9_-]*$" : {
                 "properties": {
-                    "Components" : { "$ref": "http://hamlet.io/static/schema/latest/component.json#" }
+                    "Components" : { "$ref": "http://hamlet.io/schema/latest/component.json#" }
                 }
             }
         }

--- a/static/schema/latest/blueprint.json
+++ b/static/schema/latest/blueprint.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://hamlet.io/static/schema/latest/blueprint.json",
+
+    "type": "object",
+
+    "properties": {
+      "$schema" : {
+        "type" : "string"
+      },
+      "Solution" : {
+          "type" : "object",
+          "properties": {
+              "Id" : {
+                  "type" : "string"
+              },
+              "Name" : {
+                  "type" : "string"
+              }
+          }
+      },
+      "Tiers" : {
+        "patternProperties": {
+            "^[A-Za-z0-9_-]*$" : {
+                "properties": {
+                    "Components" : { "$ref": "http://hamlet.io/static/schema/latest/component.json#" }
+                }
+            }
+        }
+      }
+    }
+}

--- a/static/schema/latest/blueprint.json
+++ b/static/schema/latest/blueprint.json
@@ -23,7 +23,7 @@
         "patternProperties": {
             "^[A-Za-z0-9_-]*$" : {
                 "properties": {
-                    "Components" : { "$ref": "http://hamlet.io/schema/latest/component.json#" }
+                    "Components" : { "$ref": "http://hamlet.io/schema/latest/blueprint/component.json#" }
                 }
             }
         }

--- a/static/schema/latest/blueprint/component.json
+++ b/static/schema/latest/blueprint/component.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://hamlet.io/schema/latest/component.json",
+    "$id": "http://hamlet.io/schema/latest/blueprint/component.json",
 
     "definitions": {
 

--- a/static/schema/latest/component.json
+++ b/static/schema/latest/component.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://hamlet.io/static/schema/latest/component.json",
+    "$id": "http://hamlet.io/schema/latest/component.json",
 
     "definitions": {
 

--- a/static/schema/latest/component.json
+++ b/static/schema/latest/component.json
@@ -1,0 +1,209 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://hamlet.io/static/schema/latest/component.json",
+
+    "definitions": {
+
+      "deployment-units" : {
+        "type" : "array",
+        "items" : {
+          "type" : "string"
+        }
+      },
+
+      "instances" : {
+        "type" : "object",
+        "additionalProperties": true,
+        "properties": {
+          "Versions" : {
+            "type" : "object",
+            "additionalProperties": true
+          }
+        }
+      },
+
+      "s3": {
+        "type": "object",
+        "properties": {
+          "Instances" : { "$ref": "#/definitions/instances" },
+          "DeploymentUnits" : { "$ref" : "#/definitions/deployment-units" },
+          "Lifecycle": {
+            "type": "object",
+            "additionalProperties" : false,
+            "properties": {
+              "Expiration" : {
+                "description": "Provide either a date or a number of days",
+                "type" : [ "string", "number" ]
+              },
+              "Offline" : {
+                "description" : "Provide either a date or a number of days",
+                "type" : [ "string", "number" ]
+              },
+              "Versioning" : {
+                "type" : "boolean",
+                "default" : false
+              }
+            }
+          },
+          "Website" : {
+            "type" : "object",
+            "additionalProperties" : false,
+            "properties": {
+              "Index" : {
+                "type" : "string",
+                "default" : "index.html"
+              },
+              "Error" : {
+                "type" : "string",
+                "default" : ""
+              }
+            }
+          },
+          "PublicAccess" : {
+            "type" : "object",
+            "patternProperties": {
+              "^[A-Za-z_][A-Za-z0-9_]*$" : {
+                "type" : "object",
+                "additionalProperties" : false,
+                "properties": {
+                  "Enabled" : {
+                    "type" : "boolean",
+                    "default" : false
+                  },
+                  "Permissions" : {
+                    "type" : "string",
+                    "enum": [ "ro", "wo", "rw"],
+                    "default" : "ro"
+                  },
+                  "IPAddressGroups" : {
+                    "type" : "array",
+                    "items": {
+                      "type" : "string"
+                    },
+                    "default" : [ "_localnet"]
+                  },
+                  "Paths" : {
+                    "type" : "array",
+                    "items": {
+                      "type" : "string"
+                    },
+                    "default" : []
+                  }
+                }
+              }
+            }
+          },
+          "Style" : {
+            "description": "TODO(mfl): Think this can be removed",
+            "type" : "string"
+          },
+          "Notifications" : {
+                "type" : "object",
+                "patternProperties": {
+                  "^[A-Za-z_][A-Za-z0-9_]*$" : {
+                    "type" : "object",
+                    "additionalProperties" : false,
+                    "properties": {
+                      "Prefix" : {
+                        "type" : "string"
+                      },
+                      "Suffix" : {
+                        "type" : "string"
+                      },
+                      "Events" : {
+                        "type" : "array",
+                        "default" : [ "create" ],
+                        "items" : {
+                          "type" : "string",
+                          "enum": [ "create", "delete", "restore", "reducedredundancy"]
+                        }
+                      }
+                    }
+                  }
+            },
+            "additionalProperties": false
+          },
+          "additionalProperties" : false
+        }
+      },
+
+      "template" : {
+        "type" : "object",
+
+        "properties": {
+          "Instances" : { "$ref": "#/definitions/instances" },
+          "DeploymentUnits" : { "$ref" : "#/definitions/deployment-units" },
+          "RootFile" : {
+            "type" : "string",
+            "description": "The name of the root template file in the build aretefact"
+          },
+          "Fragment" : {
+            "type" : "string"
+          },
+          "Parameters" : {
+            "type" : "object",
+            "patternProperties": {
+              "^[A-Za-z_][A-Za-z0-9_]*$" : {
+                "additionalProperties" : false,
+                "type" : "object",
+                "properties": {
+                  "Key" : {
+                    "type" : "string"
+                  },
+                  "Value" : {
+                    "type" : "string"
+                  }
+                },
+
+                "required": [ "Key "]
+              }
+            }
+          },
+          "Attributes" : {
+            "type" : "object",
+            "patternProperties" : {
+              "^[A-Za-z_][A-Za-z0-9_]*$" : {
+                "additionalProperties" : false,
+                "type" : "object",
+                "properties" : {
+                  "TemplateOutputKey" : {
+                    "description": "The name of the template output you want to map to an attribte",
+                    "type" : "string"
+                  },
+                  "AttributeType" : {
+                    "description": "The output type to map the attribute with",
+                    "enum": [ "dns", "arn", "url", "name", "ipaddress", "key", "port", "username", "password", "region"],
+                    "type" : "string"
+                  }
+                },
+
+                "required" : [ "TemplateOutputKey", "AttributeType" ]
+              }
+            }
+          },
+          "NetworkAccess" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        },
+        "additionalProperties": false,
+
+        "required": [ "RootFile"]
+      }
+
+    },
+
+    "type": "object",
+
+    "patternProperties": {
+      "^[A-Za-z0-9_-]*$" : {
+        "properties": {
+          "s3" : { "$ref" : "#/definitions/s3"},
+          "template" : { "$ref" : "#/definitions/template"}
+        },
+        "additionalProperties": true
+      }
+    },
+
+    "additionalProperties" : false
+}


### PR DESCRIPTION
## Description
Add initial schema documents for the hamlet blueprint. This allows for the schema to be referenced in users hamlets for intellisense and validation.

Schema documents will be available under 
```
https://hamlet.io/schema/<version>/<root object type>.json
```

If the root object has sub schemas they are available under 

```
https://hamlet.io/schema/<version>/<root object type>/<sub schema>.json
```

When using the schema a hamlet user can add the following to any of the *.json files in the infrastructure/solutions folder 

```
"$schema": "https://hamlet.io/schema/<version>/blueprint.json#",
```

## Target Audience
- [X] hamlet users
- [X] hamlet framework developers (incl. plugins)

## Types of changes
#### Documentation
- [ ] Spelling / Syntax correction only
- [ ] Refactor (Documentation overhaul, or revising after changes to hamlet)
- [X] New feature (Documenting something new)
#### Site Design
- [ ] Refactor (No new or removed content.)
- [ ] New Features & Content
- [ ] Docusaurus / Plugin version update.

## Followup Actions
- [x] None

## Checklist:
- [ ] I have tested the changes locally - see [README.md](https://github.com/hamlet-io/docs/blob/master/README.md)
- [ ] I have added appropriate labels to this PR.
- [ ] I have added this to the `hamlet roadmap` project.

