### PR TITLE
refactor: move blog to top header

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,10 +9,10 @@ module.exports = {
   themeConfig: {
     disableDarkMode: true,
     navbar: {
-      title: 'hamlet',	
-      logo: {	
-        alt: 'hamlet',	
-        src: 'img/icon.svg',	
+      title: 'hamlet',
+      logo: {
+        alt: 'hamlet',
+        src: 'img/icon.svg',
       },
       links: [
         {to: 'docs/hello/welcome', label: 'docs', position: 'left'},
@@ -34,14 +34,11 @@ module.exports = {
             },
           ],
         },
+        {to: "blog", label: 'blog', position: 'right'},
         {
           label: 'releases',
           position: 'right',
           items: [
-            {
-              label: 'latest updates',
-              to: 'blog',
-            },
             {
               label: 'strategy',
               to: 'docs/releases/schedule',
@@ -92,7 +89,7 @@ module.exports = {
           title: 'Community',
           items: [
             {
-              label: 'Latest Releases',
+              label: 'Blog',
               to: 'blog',
             },
             {


### PR DESCRIPTION
## Description
Minor refactor to move the blog to its own top level heading instead of the releases section

## Target Audience
- [X] hamlet users
- [X] hamlet framework developers (incl. plugins)

## Types of changes
#### Site Design
- [X] Refactor (No new or removed content.)
- [ ] New Features & Content
- [ ] Docusaurus / Plugin version update.

## Followup Actions
- [x] None

## Checklist:
- [ ] I have tested the changes locally - see [README.md](https://github.com/hamlet-io/docs/blob/master/README.md)
- [ ] I have added appropriate labels to this PR.
- [ ] I have added this to the `hamlet roadmap` project.

