### PR TITLE
Subdomain docsite

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ git push --set-upstream origin feature-my-feature-branch
 # on Github, create a PR from your fork/feature-branch to upstream/master.
 # make sure you complete any Issue/PR templates provided.
 ```
+
+## Production
+### Deployment
+The production instance of the docs site is hosted on Vercel, do not be confused by the deploy script in package.json. This is not used and is defunct. The publishing to Vercel is directly controlled by changes made to master and picked up by a Vercel app.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   title: 'hamlet',
   tagline: 'Opinionated, ConfigFirst DevOps for everyone.',
-  url: 'https://hamlet.io',
+  url: 'https://docs.hamlet.io',
   baseUrl: '/',
   favicon: 'img/favicon.ico',
   organizationName: 'hamlet', // Usually your GitHub org/user name.
@@ -107,7 +107,7 @@ module.exports = {
           items: [
             {
               label: 'Overview',
-              href: 'https://hamlet.io/docs/developer-guides/index'
+              href: 'https://docs.hamlet.io/docs/developer-guides/index'
             },
             {
               label: 'Docs',


### PR DESCRIPTION
Shift docsite to docs.hamlet.io and use Route53 as delegate for hamlet.io

## Description
Add to Route53/hosted zones for existing hamlet.io
 - docs.hamlet.io	CNAME	Simple	-	cname.vercel-dns.com
 - help.hamlet.io	CNAME	Simple	-	hamlet.zendesk.com

Update Route53/Registered domains for existing hamlet.io, change name servers to be
 - ns-1552.awsdns-02.co.uk
 - ns-1231.awsdns-25.org
 - ns-981.awsdns-58.net
 - ns-403.awsdns-50.com

Reconfigure site to use docs.hamlet.io as the base of the docsite (this PR)

## Target Audience
<!--- Who is the documentation targetted at? -->
- [ ] hamlet users
- [x] hamlet framework developers (incl. plugins)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
#### Documentation
- [ ] Spelling / Syntax correction only
- [x] Refactor (Documentation overhaul, or revising after changes to hamlet)
- [ ] New feature (Documenting something new)
#### Site Design
- [x] Site relocation
- [ ] Refactor (No new or removed content.)
- [ ] New Features & Content
- [ ] Docusaurus / Plugin version update.

## Followup Actions
- [x] Confirm certificate validity
- [x] Confirm access via https://docs.hamlet.io
- [x] Determine handling of access to https://hamlet.io
- [ ] None

