### PR TITLE
[Fix] - Schema Examples Recursion Bug

### DIFF
--- a/src/components/HamletJsonSchema/index.js
+++ b/src/components/HamletJsonSchema/index.js
@@ -247,6 +247,10 @@ function getSchemaExample(definition){
 
   var example = new Object;
 
+  if (definition["$ref"]) {
+    definition.type = "link-object";
+  }
+
   if (definition.type || definition.anyOf) {
     var type = (definition.anyOf) ? definition.anyOf.map(a => a.type).join(' or ') : definition.type;
     example = new String;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Correct bug in schema examples generation.

Currently the recursive function that generates the example
codeblocks for reference data types does not account for a
function call where there is no definition.type value.

In the case of a $ref to another JSONschema, the object will
look like:

{
  "$ref" : "path-to-other-schema.json"
}

Though the datatables functions accounted for $ref, the
examples did not. This commit corrects this oversight.

Closes #95

## Target Audience
<!--- For documentation-only updates. -->
<!--- Remove this section if PR does not involve Documentation. -->
<!--- Who is the documentation targetted at? -->
- [x] hamlet users
- [ ] hamlet framework developers (incl. plugins)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
#### Documentation
- [ ] Spelling / Syntax correction only
- [ ] Refactor (Documentation overhaul, or revising after changes to hamlet)
- [ ] New feature (Documenting something new)
#### Site Design
- [x] Refactor (No new or removed content.)
- [ ] New Features & Content
- [ ] Docusaurus / Plugin version update.

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested the changes locally - see [README.md](https://github.com/hamlet-io/docs/blob/master/README.md)
- [x] I have added appropriate labels to this PR.
- [x] I have added this to the `hamlet roadmap` project.

