### PR TITLE
Refactor - Schema Reference Data to Show Pattern Properties

### DIFF
--- a/src/components/DataTables/index.js
+++ b/src/components/DataTables/index.js
@@ -177,7 +177,7 @@ const getJsonSchemaDataTables = ({data, type}) => {
       // construct attribute data tables
       var dataTables = getDataTables(title, referenceAttributeRoot, mandatory);
       var example = new Object;
-      example[title] = getSchemaExample(referenceAttributeRoot);
+      example = getSchemaExample(data.definitions[title]);
 
       // add the reference
       references.push(

--- a/src/components/HamletJsonSchema/index.js
+++ b/src/components/HamletJsonSchema/index.js
@@ -251,23 +251,21 @@ function getSchemaExample(definition){
     definition.type = "link-object";
   }
 
-  if (definition.type || definition.anyOf) {
-    var type = (definition.anyOf) ? definition.anyOf.map(a => a.type).join(' or ') : definition.type;
-    example = new String;
-    example = type;
-    return example;
+  example = 
+    (definition.patternProperties) ? { "*" : getSchemaExample(definition.patternProperties[patternPropertiesRegex].properties ) }
+    : (definition.properties) ? getSchemaExample(definition.properties)
+    : (definition.anyOf) ? definition.anyOf.map(a => a.type).join(' or ')
+    : (definition.type) ? definition.type
+    : new Object
+    
+   // process children
+  if (Object.keys(example).length == 0) {
+    Object.keys(definition).map(attrName => {
+      example[attrName] = getSchemaExample(definition[attrName]);
+      return example
+    });
+
   }
-
-  Object.keys(definition).map(attrName => {
-    var attrValue = definition[attrName];
-    example[attrName] = 
-      (attrValue.patternProperties) ? getSchemaExample(attrValue.patternProperties[patternPropertiesRegex].properties)
-      : (attrValue.properties) ? getSchemaExample(attrValue.properties)
-      : getSchemaExample(attrValue)
-
-    return example;
-  });
-
   return example;
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
In JSONSchema "patternProperties" properties represent property
names that match a provided regex pattern. In Hamlet schemas this
is used to reference part of a JSON structure that is to be
defined by the file's author. Most commonly this is the object
"id".

Such properties are very important to understanding the expected
JSON structure, but have thus far not been accounted for in
examples on the website. This PR introduces an asterisk "*" to
represent patternProperties, indicating to the user that this is
necessary but self-defined.

## Target Audience
<!--- For documentation-only updates. -->
<!--- Remove this section if PR does not involve Documentation. -->
<!--- Who is the documentation targetted at? -->
- [x] hamlet users
- [ ] hamlet framework developers (incl. plugins)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
#### Documentation
- [ ] Spelling / Syntax correction only
- [x] Refactor (Documentation overhaul, or revising after changes to hamlet)
- [ ] New feature (Documenting something new)
#### Site Design
- [ ] Refactor (No new or removed content.)
- [ ] New Features & Content
- [ ] Docusaurus / Plugin version update.

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested the changes locally - see [README.md](https://github.com/hamlet-io/docs/blob/master/README.md)
- [x] I have added appropriate labels to this PR.
- [x] I have added this to the `hamlet roadmap` project.

