### PR TITLE
Refactor - Reference DataTable Layout

### DIFF
--- a/src/components/DataTables/index.js
+++ b/src/components/DataTables/index.js
@@ -241,6 +241,7 @@ function HamletDataTables() {
                       title={table.title}
                       data={table.data}
                     />
+                    <br />
                   </section>
                 )
               })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Minor change that implements a line break after each `<HamletDataTable />` component rather than having them meld into each other

## Target Audience
<!--- For documentation-only updates. -->
<!--- Remove this section if PR does not involve Documentation. -->
<!--- Who is the documentation targetted at? -->
- [x] hamlet users
- [ ] hamlet framework developers (incl. plugins)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
#### Documentation
- [ ] Spelling / Syntax correction only
- [ ] Refactor (Documentation overhaul, or revising after changes to hamlet)
- [ ] New feature (Documenting something new)
#### Site Design
- [x] Refactor (No new or removed content.)
- [ ] New Features & Content
- [ ] Docusaurus / Plugin version update.

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested the changes locally - see [README.md](https://github.com/hamlet-io/docs/blob/master/README.md)
- [x] I have added appropriate labels to this PR.
- [x] I have added this to the `hamlet roadmap` project.

