### PR TITLE
Docs: Brief guide on Blueprint Validation

### DIFF
--- a/docs/learn/validate.md
+++ b/docs/learn/validate.md
@@ -11,24 +11,26 @@ In this short guide we'll take a look over how you can make the most of Blueprin
 ## Requirements
 
 The following sections assume you are working inside the development workspace and have a District configured already.
+## What Gets Validated?
 
-## Running Validation
-
-Validation is performed as an Engine Entrance.
-
-
-```bash
-hamlet entrance invoke-entrance -e validate
-```
-
-This will construct the Blueprint from the layers of the District  and bring to your attention any of the following:
+The validation process will construct the District's Blueprint and compare it against the [Blueprint Reference](https://docs.hamlet.io/reference). The process will alert you if any of the following issues are present:
 
 - missing mandatory configuration;
 - unexpected data types;
 - values that do not match those available (where applicable)
 - unexpected attributes have been found;
 
-Should any of the above be present Hamlet Deploy will provide you with the cause of the invalid configuration and which configuration it was found within.
+## Running Validation
+
+Validation is performed as an Engine Entrance. It does not require any additional arguments.
+
+```bash
+hamlet entrance invoke-entrance -e validate
+```
+
+That's all there is to it!
+
+Regular validation will help you catch issues early and ensure that Hamlet Deploy is working the way you intend it to.
 
 <Admonition type="question" title="Having Trouble?">
 You can always compare invalid configuration against the <a href="https://docs.hamlet.io/reference">Blueprint Reference</a> if you get stuck.

--- a/docs/learn/validate.md
+++ b/docs/learn/validate.md
@@ -1,0 +1,35 @@
+---
+sidebar_label: validate configuration
+title: Validating the Blueprint
+---
+import Admonition from 'react-admonitions';
+
+Regularly validating that your Blueprint contains only valid configuration is not only good practice, it will help you catch mis-configurations early.
+
+In this short guide we'll take a look over how you can make the most of Blueprint validation.
+
+## Requirements
+
+The following sections assume you are working inside the development workspace and have a District configured already.
+
+## Running Validation
+
+Validation is performed as an Engine Entrance.
+
+
+```bash
+hamlet entrance invoke-entrance -e validate
+```
+
+This will construct the Blueprint from the layers of the District  and bring to your attention any of the following:
+
+- missing mandatory configuration;
+- unexpected data types;
+- values that do not match those available (where applicable)
+- unexpected attributes have been found;
+
+Should any of the above be present Hamlet Deploy will provide you with the cause of the invalid configuration and which configuration it was found within.
+
+<Admonition type="question" title="Having Trouble?">
+You can always compare invalid configuration against the [Blueprint Reference](https://docs.hamlet.io/reference) if you get stuck.
+</Admonition>

--- a/docs/learn/validate.md
+++ b/docs/learn/validate.md
@@ -31,5 +31,5 @@ This will construct the Blueprint from the layers of the District  and bring to 
 Should any of the above be present Hamlet Deploy will provide you with the cause of the invalid configuration and which configuration it was found within.
 
 <Admonition type="question" title="Having Trouble?">
-You can always compare invalid configuration against the [Blueprint Reference](https://docs.hamlet.io/reference) if you get stuck.
+You can always compare invalid configuration against the <a href="https://docs.hamlet.io/reference">Blueprint Reference</a> if you get stuck.
 </Admonition>

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,6 +20,7 @@ module.exports = {
             'learn/layers/blueprint',
           ]
         },
+        'learn/validate'
       ]
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides a brief guide of how and why to validate a Blueprint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Validation is a really helpful learning tool and learning it is there and how to use it early will reduce the learning curve for Hamlet Deploy

Requires hamlet-io/engine#1548

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Docs
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
