### PR TITLE
feat: add scheduled run of schema updates

### DIFF
--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - "master"
+  schedule:
+    - cron: '00 00 * * *'
 
 jobs:
   hamlet-schema-updater:
@@ -13,7 +15,7 @@ jobs:
     steps:
       - name: Checkout Docs Site
         uses: actions/checkout@v2
-      
+
       - name: Generate Hamlet Schemas
         uses: hamlet-io/github-action-hamlet@v1
         with:


### PR DESCRIPTION
## Description

Adds a regular update of the schemas

## Motivation and Context

Ensures that we have the latest schemas +/- 1 day at all times. Schema changes are made in the engine and since there isn't a trigger for changes from the engine to the docs site a simple solution is to generate the schema on a regular basis. 

## How Has This Been Tested?

Will be tested through github actions

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
