### PR TITLE
refactor: split large recursive datatables function into two

### DIFF
--- a/src/components/HamletJsonSchema/index.js
+++ b/src/components/HamletJsonSchema/index.js
@@ -243,25 +243,30 @@ function getJsonSchemaData(type, instance){
   return result;
 };
 
-function getSchemaExample(definition){
+function getSchemaExample(data){
 
   var example = new Object;
 
-  if (definition["$ref"]) {
-    definition.type = "link-object";
+  if (data["$ref"]) {
+    data.type = "link-object";
   }
 
-  example = 
-    (definition.patternProperties) ? { "*" : getSchemaExample(definition.patternProperties[patternPropertiesRegex].properties ) }
-    : (definition.properties) ? getSchemaExample(definition.properties)
-    : (definition.anyOf) ? definition.anyOf.map(a => a.type).join(' or ')
-    : (definition.type) ? definition.type
-    : new Object
+  if (data?.definitions) {
+    example = getSchemaExample(Object.values(
+      data.definitions)[0].patternProperties[patternPropertiesRegex].properties)
+  } else {
+    example = 
+      (data.patternProperties) ? { "*" : getSchemaExample(data.patternProperties[patternPropertiesRegex].properties ) }
+      : (data.properties) ? getSchemaExample(data.properties)
+      : (data.anyOf) ? data.anyOf.map(a => a.type).join(' or ')
+      : (data.type) ? data.type
+      : new Object
+  }
     
    // process children
   if (Object.keys(example).length == 0) {
-    Object.keys(definition).map(attrName => {
-      example[attrName] = getSchemaExample(definition[attrName]);
+    Object.keys(data).map(attrName => {
+      example[attrName] = getSchemaExample(data[attrName]);
       return example
     });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Refactor to the getDataTables function that transforms JSONSchema into the reference data tables

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The getDataTables function is unwieldy and hard to maintain. It's recursive,
however the data structures are different at several levels. The function
returns an array of datatables, with pre-processed attributes for rows.

This refactor replaces the single function with two:

* getDataTablesList
* getDataTableRows

getDataTablesList determines the dataTables that will be required for a schema,
and for each table it returns the table name, and its raw data.

getDataTableRows is then used to process this raw data and determine the table
rows required (schema attributes) - it does not need to recurse into children
because that will be in another dataTable.

Together, these functions are far simpler to maintain.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] None of the above.
