### PR TITLE
chore: clean schema dir before regeneration

### DIFF
--- a/.github/workflows/update-schemas.yml
+++ b/.github/workflows/update-schemas.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           task_build_schemas: true
           task_build_schemas_output: /github/workspace/static/schema/latest/blueprint
+          refresh_output_dir: true
 
       - name: Commit Schemas into Repo
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Chore - general repo hygiene

## Description
<!--- Describe your changes in detail -->
Delete content of the schema directory prior to generating new schema files

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Bugs in the engine in the past have caused the schemas to be generated with an incorrect filename. When that was fixed, there was unnecessary and incorrect schemas left in the docs site (alongside the new and correct ones). This required manual intervention. This will instead flush such issues after engine fix.

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
N/a

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None
