### PR TITLE
feat: add layer schemas to datatables

### DIFF
--- a/src/components/HamletJsonSchema/index.js
+++ b/src/components/HamletJsonSchema/index.js
@@ -117,6 +117,14 @@ import userpoolclient from "@site/static/schema/latest/blueprint/schema-componen
 import userpoolauthprovider from "@site/static/schema/latest/blueprint/schema-component-userpoolauthprovider-schema.json";
 import userpoolresource from "@site/static/schema/latest/blueprint/schema-component-userpoolresource-schema.json";
 
+import accountSchema from "@site/static/schema/latest/blueprint/schema-layer-account-schema.json";
+import environmentSchema from "@site/static/schema/latest/blueprint/schema-layer-environment-schema.json";
+import productSchema from "@site/static/schema/latest/blueprint/schema-layer-product-schema.json";
+import regionSchema from "@site/static/schema/latest/blueprint/schema-layer-region-schema.json";
+import segmentSchema from "@site/static/schema/latest/blueprint/schema-layer-segment-schema.json";
+import solutionSchema from "@site/static/schema/latest/blueprint/schema-layer-solution-schema.json";
+import tenantSchema from "@site/static/schema/latest/blueprint/schema-layer-tenant-schema.json";
+
 const patternPropertiesRegex = "^[A-Za-z_][A-Za-z0-9_]*$";
 
 const schema = {
@@ -235,6 +243,15 @@ const schema = {
   },
   attributeset: {
       link: { data: linkSchema },
+  },
+  layer: {
+    account: { data: accountSchema },
+    environment: { data: environmentSchema },
+    product: { data: productSchema },
+    region: { data: regionSchema },
+    segment: { data: segmentSchema },
+    solution: { data: solutionSchema },
+    tenant: { data: tenantSchema },
   }
 };
 

--- a/src/pages/reference/index.js
+++ b/src/pages/reference/index.js
@@ -24,6 +24,19 @@ function HamletRefRouter() {
             >
               <ul style={{ listStyleType: "none", padding: 0 }}>
                 <br />
+                <h2>Layers</h2>
+                {Object.keys(schema.layer).map((instance) => (
+                  <React.Fragment>
+                    <li>
+                      <Link
+                        to={`/reference?type=layer&instance=${instance}`}
+                      >
+                        {instance}
+                      </Link>
+                    </li>
+                  </React.Fragment>
+                ))}
+                <br />
                 <h2>Attribute Sets</h2>
                 {Object.keys(schema.attributeset).map((instance) => (
                   <React.Fragment>


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Documentation (new or update to existing)

## Description
<!--- Describe your changes in detail -->
Adds the Layer JSONSchemas to the Reference Data data tables

Requires hamlet-io/engine#1633 (& subsequent run of the GitHub Action that will add these schemas to the docs repo)

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Document all structures

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
Tested locally

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None
